### PR TITLE
Fix student edit dialog styling for short screens

### DIFF
--- a/.cursor/rules/modal-forms.md
+++ b/.cursor/rules/modal-forms.md
@@ -1,0 +1,186 @@
+# Modal Forms Setup Rule
+
+## Overview
+When creating modals with forms in this project, always use the proper structure to ensure the form content is scrollable on short screens and action buttons are always accessible.
+
+## Required Structure
+
+### 1. Modal Container
+```vue
+<UModal v-model:open="modelValue">
+  <template #content>
+    <UCard class="max-h-[90vh] flex flex-col">
+      <!-- Header, Content, Footer structure -->
+    </UCard>
+  </template>
+</UModal>
+```
+
+### 2. Card Structure with Three Sections
+```vue
+<UCard class="max-h-[90vh] flex flex-col">
+  <!-- Header - Always visible -->
+  <template #header>
+    <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+      {{ modalTitle }}
+    </h3>
+  </template>
+
+  <!-- Scrollable Content Area -->
+  <div class="flex-1 overflow-y-auto">
+    <UForm :state="form" class="space-y-4" @submit="handleSubmit" ref="formRef">
+      <!-- Form fields go here -->
+    </UForm>
+  </div>
+
+  <!-- Footer - Always visible with action buttons -->
+  <template #footer>
+    <div class="flex justify-end gap-3">
+      <UButton @click="handleCancel" variant="ghost">
+        {{ $t('common.cancel') }}
+      </UButton>
+      <UButton @click="() => formRef?.submit()" :loading="submitting" color="primary">
+        {{ $t('common.save') }}
+      </UButton>
+    </div>
+  </template>
+</UCard>
+```
+
+## Key CSS Classes
+
+- `max-h-[90vh]` - Limits modal height to 90% of viewport
+- `flex flex-col` - Enables vertical flexbox layout
+- `flex-1` - Makes content area take remaining space
+- `overflow-y-auto` - Enables vertical scrolling when content overflows
+
+## Script Setup Requirements
+
+### 1. Form Reference
+```vue
+<script setup lang="ts">
+const formRef = ref()
+// ... other code
+</script>
+```
+
+### 2. Form Submission Handling
+```vue
+// Use formRef to submit the form from footer buttons
+<UButton @click="() => formRef?.submit()" :loading="submitting" color="primary">
+  {{ $t('common.save') }}
+</UButton>
+```
+
+## Best Practices
+
+### 1. Always Use This Structure
+- Never put forms directly in the card body without the scrollable wrapper
+- Always separate header, content, and footer sections
+- Always use the footer template for action buttons
+
+### 2. Form Validation
+- Use `UForm` component with proper state management
+- Include error handling with `UAlert` components
+- Validate form data before submission
+
+### 3. Responsive Design
+- Use `space-y-4` for consistent spacing between form fields
+- Use `grid` layouts for responsive field arrangements
+- Test on different screen sizes
+
+### 4. Accessibility
+- Include proper labels for all form fields
+- Use semantic HTML structure
+- Ensure keyboard navigation works properly
+
+## Example Implementation
+
+```vue
+<template>
+  <UModal v-model:open="modelValue">
+    <template #content>
+      <UCard class="max-h-[90vh] flex flex-col">
+        <template #header>
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+            {{ isEditing ? $t('item.editItem') : $t('item.addItem') }}
+          </h3>
+        </template>
+
+        <div class="flex-1 overflow-y-auto">
+          <UForm :state="form" class="space-y-4" @submit="handleSubmit" ref="formRef">
+            <UFormField name="name" :label="$t('item.name')" required>
+              <UInput v-model="form.name" class="w-full" :placeholder="$t('item.namePlaceholder')" />
+            </UFormField>
+
+            <UFormField name="description" :label="$t('item.description')">
+              <UTextarea v-model="form.description" class="w-full" :placeholder="$t('item.descriptionPlaceholder')" :rows="3" />
+            </UFormField>
+
+            <UAlert v-if="error" color="error" variant="soft" :title="$t('common.error')" :description="error" />
+          </UForm>
+        </div>
+
+        <template #footer>
+          <div class="flex justify-end gap-3">
+            <UButton @click="handleCancel" variant="ghost">
+              {{ $t('common.cancel') }}
+            </UButton>
+            <UButton @click="() => formRef?.submit()" :loading="submitting" color="primary">
+              {{ isEditing ? $t('common.save') : $t('common.add') }}
+            </UButton>
+          </div>
+        </template>
+      </UCard>
+    </template>
+  </UModal>
+</template>
+
+<script setup lang="ts">
+const modelValue = defineModel<boolean>()
+const formRef = ref()
+const submitting = ref(false)
+const error = ref('')
+
+const form = reactive({
+  name: '',
+  description: ''
+})
+
+const handleSubmit = async () => {
+  // Form submission logic
+}
+
+const handleCancel = () => {
+  modelValue.value = false
+}
+</script>
+```
+
+## Common Mistakes to Avoid
+
+1. **Don't** put forms directly in card body without scrollable wrapper
+2. **Don't** put action buttons inside the scrollable content area
+3. **Don't** forget to add `formRef` for form submission
+4. **Don't** use fixed heights that might break on different screen sizes
+5. **Don't** forget to handle form validation and error states
+
+## Testing Checklist
+
+- [ ] Modal opens and closes properly
+- [ ] Form content scrolls when screen is short
+- [ ] Action buttons are always visible
+- [ ] Form validation works correctly
+- [ ] Error messages display properly
+- [ ] Modal works on mobile devices
+- [ ] Keyboard navigation works
+- [ ] Form submission works from footer buttons
+
+## Related Components
+
+This rule applies to all modal forms in the project:
+- `StudentForm.vue`
+- `PackageForm.vue`
+- `AddPackageToStudent.vue`
+- `ScheduleModal.vue`
+- Any future modal forms

--- a/components/AddPackageToStudent.vue
+++ b/components/AddPackageToStudent.vue
@@ -1,129 +1,124 @@
 <template>
   <UModal v-model:open="modelValue">
     <template #content>
-      <UCard>
+      <UCard class="max-h-[90vh] flex flex-col">
         <template #header>
           <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
             {{ t('student.addPackageToStudent', { name: student?.name }) }}
           </h3>
         </template>
 
-        <UForm :state="form" class="space-y-4" @submit="handleSubmit">
-          <!-- Package Type Toggle -->
-          <div class="flex gap-4 mb-4">
-            <UButton
-              @click="form.package_type = 'existing'"
-              :variant="form.package_type === 'existing' ? 'solid' : 'ghost'"
-              size="sm"
-            >
-              {{ t('student.existingPackage') }}
-            </UButton>
-            <UButton
-              @click="form.package_type = 'custom'"
-              :variant="form.package_type === 'custom' ? 'solid' : 'ghost'"
-              size="sm"
-            >
-              {{ t('student.customPackage') }}
-            </UButton>
-          </div>
-
-          <!-- Existing Package Selection -->
-          <UFormField
-            v-if="form.package_type === 'existing'"
-            name="package_id"
-            :label="t('student.selectPackage')"
-            required
-          >
-            <USelect
-              v-model="form.package_id"
-              class="w-full"
-              :placeholder="t('student.selectPackagePlaceholder')"
-              :items="packageOptions"
-              :loading="packagesLoading"
-            />
-          </UFormField>
-
-          <!-- Custom Package Form -->
-          <div v-if="form.package_type === 'custom'" class="space-y-4">
-            <!-- Auto-generated package name preview -->
-            <div class="p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
-              <div class="text-sm text-gray-600 dark:text-gray-400 mb-1">
-                {{ t('student.packageNamePreview') }}:
-              </div>
-              <div class="font-medium text-gray-900 dark:text-white">
-                {{ generatedPackageName }}
-              </div>
+        <div class="flex-1 overflow-y-auto">
+          <UForm :state="form" class="space-y-4" @submit="handleSubmit" ref="formRef">
+            <!-- Package Type Toggle -->
+            <div class="flex gap-4 mb-4">
+              <UButton
+                @click="form.package_type = 'existing'"
+                :variant="form.package_type === 'existing' ? 'solid' : 'ghost'"
+                size="sm"
+              >
+                {{ t('student.existingPackage') }}
+              </UButton>
+              <UButton
+                @click="form.package_type = 'custom'"
+                :variant="form.package_type === 'custom' ? 'solid' : 'ghost'"
+                size="sm"
+              >
+                {{ t('student.customPackage') }}
+              </UButton>
             </div>
 
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <UFormField
-                name="custom_package_duration"
-                :label="t('package.durationDays')"
-                required
-              >
-                <UInput
-                  v-model.number="form.custom_package_duration"
-                  type="number"
-                  class="w-full"
-                  :placeholder="t('package.durationDaysPlaceholder')"
-                  min="1"
-                />
-              </UFormField>
+            <!-- Existing Package Selection -->
+            <UFormField
+              v-if="form.package_type === 'existing'"
+              name="package_id"
+              :label="t('student.selectPackage')"
+              required
+            >
+              <USelect
+                v-model="form.package_id"
+                class="w-full"
+                :placeholder="t('student.selectPackagePlaceholder')"
+                :items="packageOptions"
+                :loading="packagesLoading"
+              />
+            </UFormField>
 
-              <div class="grid grid-cols-2 gap-4">
+            <!-- Custom Package Form -->
+            <div v-if="form.package_type === 'custom'" class="space-y-4">
+              <!-- Auto-generated package name preview -->
+              <div class="p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
+                <div class="text-sm text-gray-600 dark:text-gray-400 mb-1">
+                  {{ t('student.packageNamePreview') }}:
+                </div>
+                <div class="font-medium text-gray-900 dark:text-white">
+                  {{ generatedPackageName }}
+                </div>
+              </div>
+
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <UFormField
-                  name="custom_package_price"
-                  :label="t('package.price')"
+                  name="custom_package_duration"
+                  :label="t('package.durationDays')"
                   required
                 >
                   <UInput
-                    v-model.number="form.custom_package_price"
+                    v-model.number="form.custom_package_duration"
                     type="number"
                     class="w-full"
-                    :placeholder="t('package.pricePlaceholder')"
-                    min="0"
-                    step="0.01"
-                  >
-                    <template #leading>
-                      $
-                    </template>
-                  </UInput>
-                </UFormField>
-
-                <UFormField
-                  name="custom_package_credits"
-                  :label="t('package.credits')"
-                  required
-                >
-                  <UInput
-                    v-model.number="form.custom_package_credits"
-                    type="number"
-                    class="w-full"
-                    :placeholder="t('package.creditsPlaceholder')"
+                    :placeholder="t('package.durationDaysPlaceholder')"
                     min="1"
                   />
                 </UFormField>
+
+                <div class="grid grid-cols-2 gap-4">
+                  <UFormField
+                    name="custom_package_price"
+                    :label="t('package.price')"
+                    required
+                  >
+                    <UInput
+                      v-model.number="form.custom_package_price"
+                      type="number"
+                      class="w-full"
+                      :placeholder="t('package.pricePlaceholder')"
+                      min="0"
+                      step="0.01"
+                    >
+                      <template #leading>
+                        $
+                      </template>
+                    </UInput>
+                  </UFormField>
+
+                  <UFormField
+                    name="custom_package_credits"
+                    :label="t('package.credits')"
+                    required
+                  >
+                    <UInput
+                      v-model.number="form.custom_package_credits"
+                      type="number"
+                      class="w-full"
+                      :placeholder="t('package.creditsPlaceholder')"
+                      min="1"
+                    />
+                  </UFormField>
+                </div>
               </div>
             </div>
 
-            <!-- Price per credit calculation -->
-            <div v-if="form.custom_package_price && form.custom_package_credits" class="text-sm text-gray-600 dark:text-gray-400">
-              {{ t('package.creditUnitPrice', { price: (form.custom_package_price / form.custom_package_credits).toFixed(2) }) }}
-            </div>
-          </div>
-
-          <!-- Custom Price Field (only for existing packages) -->
-          <UFormField
-            v-if="form.package_type === 'existing'"
-            name="custom_price"
-            :label="t('student.customPrice')"
-          >
-            <div class="relative">
+            <!-- Custom Price Override (for existing packages) -->
+            <UFormField
+              v-if="form.package_type === 'existing' && selectedPackage"
+              name="custom_price"
+              :label="t('student.customPrice')"
+            >
               <UInput
                 v-model.number="form.custom_price"
                 type="number"
                 class="w-full"
-                :placeholder="selectedPackage ? selectedPackage.price.toString() : '0'"
+                :placeholder="t('student.customPricePlaceholder')"
                 min="0"
                 step="0.01"
               >
@@ -131,75 +126,65 @@
                   $
                 </template>
               </UInput>
-            </div>
-            <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {{ t('student.customPriceHelp') }}
-            </div>
-          </UFormField>
+              <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {{ t('student.originalPrice', { price: selectedPackage.price }) }}
+              </div>
+            </UFormField>
 
-          <div v-if="selectedPackage" class="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
-            <h4 class="font-medium text-gray-900 dark:text-white mb-2">
-              {{ t('student.packageDetails') }}
-            </h4>
-            <div class="grid grid-cols-2 gap-4 text-sm">
-              <div>
-                <span class="text-gray-500 dark:text-gray-400">{{ t('package.price') }}:</span>
-                <span class="ml-2 font-medium">
-                  <span v-if="form.custom_price && form.custom_price !== selectedPackage.price" class="line-through text-gray-400">
-                    ${{ selectedPackage.price }}
-                  </span>
-                  <span :class="{ 'text-green-600 dark:text-green-400': form.custom_price && form.custom_price !== selectedPackage.price }">
-                    ${{ form.custom_price || selectedPackage.price }}
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span class="text-gray-500 dark:text-gray-400">{{ t('package.credits') }}:</span>
-                <span class="ml-2 font-medium">{{ selectedPackage.credits }}</span>
-              </div>
-              <div>
-                <span class="text-gray-500 dark:text-gray-400">{{ t('package.durationDays') }}:</span>
-                <span class="ml-2 font-medium">{{ selectedPackage.duration_days }} {{ t('package.days') }}</span>
-              </div>
-              <div>
-                <span class="text-gray-500 dark:text-gray-400">{{ t('student.expiryDate') }}:</span>
-                <span class="ml-2 font-medium">{{ formatDate(expiryDate) }}</span>
+            <!-- Package Preview -->
+            <div v-if="selectedPackage || form.package_type === 'custom'" class="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
+              <h4 class="font-medium text-gray-900 dark:text-white mb-2">
+                {{ t('student.packagePreview') }}
+              </h4>
+              <div class="space-y-1 text-sm">
+                <div class="flex justify-between">
+                  <span class="text-gray-600 dark:text-gray-400">{{ t('package.name') }}:</span>
+                  <span class="font-medium">{{ form.package_type === 'existing' ? selectedPackage?.name : generatedPackageName }}</span>
+                </div>
+                <div class="flex justify-between">
+                  <span class="text-gray-600 dark:text-gray-400">{{ t('package.price') }}:</span>
+                  <span class="font-medium">${{ form.package_type === 'existing' ? (form.custom_price || selectedPackage?.price) : form.custom_package_price }}</span>
+                </div>
+                <div class="flex justify-between">
+                  <span class="text-gray-600 dark:text-gray-400">{{ t('package.credits') }}:</span>
+                  <span class="font-medium">{{ form.package_type === 'existing' ? selectedPackage?.credits : form.custom_package_credits }}</span>
+                </div>
+                <div class="flex justify-between">
+                  <span class="text-gray-600 dark:text-gray-400">{{ t('package.durationDays') }}:</span>
+                  <span class="font-medium">{{ form.package_type === 'existing' ? selectedPackage?.duration_days : form.custom_package_duration }} {{ t('common.days') }}</span>
+                </div>
+                <div v-if="form.package_type === 'existing' && expiryDate" class="flex justify-between">
+                  <span class="text-gray-600 dark:text-gray-400">{{ t('student.expiryDate') }}:</span>
+                  <span class="font-medium">{{ expiryDate.toLocaleDateString() }}</span>
+                </div>
               </div>
             </div>
-            <div v-if="form.custom_price && form.custom_price !== selectedPackage.price" class="mt-2 text-sm">
-              <span v-if="form.custom_price < selectedPackage.price" class="text-green-600 dark:text-green-400">
-                {{ t('student.discountApplied', { discount: ((selectedPackage.price - form.custom_price) / selectedPackage.price * 100).toFixed(0) }) }}
-              </span>
-              <span v-else class="text-orange-600 dark:text-orange-400">
-                {{ t('student.priceIncrease', { increase: ((form.custom_price - selectedPackage.price) / selectedPackage.price * 100).toFixed(0) }) }}
-              </span>
-            </div>
-            <div v-if="selectedPackage.description" class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-              {{ selectedPackage.description }}
-            </div>
-          </div>
 
-          <UFormField
-            name="notes"
-            :label="t('student.notes')"
-          >
-            <UTextarea
-              v-model="form.notes"
-              class="w-full"
-              :placeholder="t('student.notesPlaceholder')"
-              :rows="3"
+            <!-- Notes -->
+            <UFormField
+              name="notes"
+              :label="t('student.notes')"
+            >
+              <UTextarea
+                v-model="form.notes"
+                class="w-full"
+                :placeholder="t('student.notesPlaceholder')"
+                :rows="3"
+              />
+            </UFormField>
+
+            <UAlert
+              v-if="error"
+              color="error"
+              variant="soft"
+              :title="t('common.error')"
+              :description="error"
+              icon="i-heroicons-exclamation-triangle"
             />
-          </UFormField>
+          </UForm>
+        </div>
 
-          <UAlert
-            v-if="error"
-            color="error"
-            variant="soft"
-            :title="t('common.error')"
-            :description="error"
-            icon="i-heroicons-exclamation-triangle"
-          />
-
+        <template #footer>
           <div class="flex justify-end gap-3">
             <UButton
               @click="handleCancel"
@@ -208,14 +193,14 @@
               {{ t('common.cancel') }}
             </UButton>
             <UButton
-              type="submit"
+              @click="() => formRef?.submit()"
               :loading="submitting"
               color="primary"
             >
               {{ t('student.addPackage') }}
             </UButton>
           </div>
-        </UForm>
+        </template>
       </UCard>
     </template>
   </UModal>
@@ -247,6 +232,7 @@ const modelValue = defineModel<boolean>()
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 
+const formRef = ref()
 const { t } = useI18n()
 const { packages, loading: packagesLoading } = usePackages()
 const { addPackageToStudent } = useStudentPackages()

--- a/components/PackageForm.vue
+++ b/components/PackageForm.vue
@@ -1,109 +1,113 @@
 <template>
   <UModal v-model:open="modelValue">
     <template #content>
-      <UCard>
+      <UCard class="max-h-[90vh] flex flex-col">
         <template #header>
           <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
             {{ isEditing ? $t('package.editPackage') : $t('package.addPackage') }}
           </h3>
         </template>
 
-        <UForm :state="form" class="space-y-4" @submit="handleSubmit">
-          <UFormField
-            name="name"
-            :label="$t('package.name')"
-            required
-          >
-            <UInput
-              v-model="form.name"
-              class="w-full"
-              :placeholder="$t('package.namePlaceholder')"
-            />
-          </UFormField>
+        <div class="flex-1 overflow-y-auto">
+          <UForm :state="form" class="space-y-4" @submit="handleSubmit" ref="formRef">
+            <UFormField
+              name="name"
+              :label="$t('package.name')"
+              required
+            >
+              <UInput
+                v-model="form.name"
+                class="w-full"
+                :placeholder="$t('package.namePlaceholder')"
+              />
+            </UFormField>
 
-          <UFormField
-            name="description"
-            :label="$t('package.description')"
-          >
-            <UTextarea
-              v-model="form.description"
-              class="w-full"
-              :placeholder="$t('package.descriptionPlaceholder')"
-              :rows="3"
-            />
-          </UFormField>
+            <UFormField
+              name="description"
+              :label="$t('package.description')"
+            >
+              <UTextarea
+                v-model="form.description"
+                class="w-full"
+                :placeholder="$t('package.descriptionPlaceholder')"
+                :rows="3"
+              />
+            </UFormField>
 
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div class="grid grid-cols-2 gap-4">
-              <UFormField
-                name="price"
-                :label="$t('package.price')"
-                required
-              >
-                <UInput
-                    v-model.number="form.price"
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div class="grid grid-cols-2 gap-4">
+                <UFormField
+                  name="price"
+                  :label="$t('package.price')"
+                  required
+                >
+                  <UInput
+                      v-model.number="form.price"
+                      type="number"
+                      class="w-full"
+                      :placeholder="$t('package.pricePlaceholder')"
+                      min="0"
+                      step="0.01"
+                    >
+                    <template #leading>
+                    $
+                    </template>
+                    </UInput>
+                  <div v-if="form.price > 0 && form.credits > 0" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {{ $t('package.creditUnitPrice', { price: (form.price / form.credits).toFixed(2) }) }}
+                  </div>
+                </UFormField>
+
+                <UFormField
+                  name="credits"
+                  :label="$t('package.credits')"
+                  required
+                >
+                  <UInput
+                    v-model.number="form.credits"
                     type="number"
                     class="w-full"
-                    :placeholder="$t('package.pricePlaceholder')"
-                    min="0"
-                    step="0.01"
-                  >
-                  <template #leading>
-                  $
-                  </template>
-                  </UInput>
-                <div v-if="form.price > 0 && form.credits > 0" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  {{ $t('package.creditUnitPrice', { price: (form.price / form.credits).toFixed(2) }) }}
-                </div>
-              </UFormField>
+                    :placeholder="$t('package.creditsPlaceholder')"
+                    min="1"
+                  />
+                </UFormField>
+              </div>
 
               <UFormField
-                name="credits"
-                :label="$t('package.credits')"
+                name="duration_days"
+                :label="$t('package.durationDays')"
                 required
               >
                 <UInput
-                  v-model.number="form.credits"
+                  v-model.number="form.duration_days"
                   type="number"
                   class="w-full"
-                  :placeholder="$t('package.creditsPlaceholder')"
+                  :placeholder="$t('package.durationDaysPlaceholder')"
                   min="1"
                 />
               </UFormField>
             </div>
 
-            <UFormField
-              name="duration_days"
-              :label="$t('package.durationDays')"
-              required
-            >
-              <UInput
-                v-model.number="form.duration_days"
-                type="number"
+            <UFormField name="active">
+              <UCheckbox
+                v-model="form.active"
                 class="w-full"
-                :placeholder="$t('package.durationDaysPlaceholder')"
-                min="1"
+                :label="$t('package.active')"
               />
             </UFormField>
-          </div>
 
-          <UFormField name="active">
-            <UCheckbox
-              v-model="form.active"
-              class="w-full"
-              :label="$t('package.active')"
+            <UAlert
+              v-if="error"
+              color="error"
+              variant="soft"
+              :title="$t('common.error')"
+              :description="error"
+              icon="i-heroicons-exclamation-triangle"
             />
-          </UFormField>
+          </UForm>
+        </div>
 
-          <UAlert
-            v-if="error"
-            color="error"
-            variant="soft"
-            :title="$t('common.error')"
-            :description="error"
-            icon="i-heroicons-exclamation-triangle"
-          />
-
+        <template #footer>
           <div class="flex justify-end gap-3">
             <UButton
               @click="handleCancel"
@@ -112,14 +116,14 @@
               {{ $t('common.cancel') }}
             </UButton>
             <UButton
-              type="submit"
+              @click="() => formRef?.submit()"
               :loading="submitting"
               color="primary"
             >
               {{ isEditing ? $t('common.save') : $t('common.add') }}
             </UButton>
           </div>
-        </UForm>
+        </template>
       </UCard>
     </template>
   </UModal>
@@ -139,6 +143,8 @@ interface Emits {
 const modelValue = defineModel<boolean>()
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
+
+const formRef = ref()
 
 const { packageSchema } = usePackageValidation()
 

--- a/components/ScheduleModal.vue
+++ b/components/ScheduleModal.vue
@@ -1,6 +1,6 @@
 <template>
   <UModal v-model="isOpen" :ui="{ width: 'sm:max-w-lg' }">
-    <UCard>
+    <UCard class="max-h-[90vh] flex flex-col">
       <template #header>
         <div class="flex items-center justify-between">
           <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
@@ -15,120 +15,122 @@
         </div>
       </template>
 
-      <form @submit.prevent="saveSchedule" class="space-y-4">
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <UFormGroup :label="$t('classes.classType')" required>
-            <USelect
-              v-model="form.class_type_id"
-              :options="classTypeOptions"
-              option-attribute="label"
-              value-attribute="value"
-              :placeholder="$t('classes.selectClassType')"
-              :error="errors.class_type_id"
-            />
-          </UFormGroup>
+      <div class="flex-1 overflow-y-auto">
+        <form @submit.prevent="saveSchedule" class="space-y-4">
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <UFormGroup :label="$t('classes.classType')" required>
+              <USelect
+                v-model="form.class_type_id"
+                :options="classTypeOptions"
+                option-attribute="label"
+                value-attribute="value"
+                :placeholder="$t('classes.selectClassType')"
+                :error="errors.class_type_id"
+              />
+            </UFormGroup>
 
-          <UFormGroup :label="$t('classes.location')" required>
-            <USelect
-              v-model="form.location_id"
-              :options="locationOptions"
-              option-attribute="label"
-              value-attribute="value"
-              :placeholder="$t('classes.selectLocation')"
-              :error="errors.location_id"
-            />
-          </UFormGroup>
-        </div>
-
-        <UFormGroup :label="$t('classes.weeklyDays')" required>
-          <div class="grid grid-cols-4 gap-2">
-            <UCheckbox
-              v-for="day in weekDays"
-              :key="day.value"
-              v-model="form.weekly_days"
-              :value="day.value"
-              :label="day.label"
-            />
+            <UFormGroup :label="$t('classes.location')" required>
+              <USelect
+                v-model="form.location_id"
+                :options="locationOptions"
+                option-attribute="label"
+                value-attribute="value"
+                :placeholder="$t('classes.selectLocation')"
+                :error="errors.location_id"
+              />
+            </UFormGroup>
           </div>
-          <p v-if="errors.weekly_days" class="text-red-500 text-sm mt-1">
-            {{ errors.weekly_days }}
-          </p>
-        </UFormGroup>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <UFormGroup :label="$t('classes.startTime')" required>
-            <UInput
-              v-model="form.start_time"
-              type="time"
-              :error="errors.start_time"
+          <UFormGroup :label="$t('classes.weeklyDays')" required>
+            <div class="grid grid-cols-4 gap-2">
+              <UCheckbox
+                v-for="day in weekDays"
+                :key="day.value"
+                v-model="form.weekly_days"
+                :value="day.value"
+                :label="day.label"
+              />
+            </div>
+            <p v-if="errors.weekly_days" class="text-red-500 text-sm mt-1">
+              {{ errors.weekly_days }}
+            </p>
+          </UFormGroup>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <UFormGroup :label="$t('classes.startTime')" required>
+              <UInput
+                v-model="form.start_time"
+                type="time"
+                :error="errors.start_time"
+              />
+            </UFormGroup>
+
+            <UFormGroup :label="$t('classes.endTime')" required>
+              <UInput
+                v-model="form.end_time"
+                type="time"
+                :error="errors.end_time"
+              />
+            </UFormGroup>
+          </div>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <UFormGroup :label="$t('classes.startDate')" required>
+              <UInput
+                v-model="form.start_date"
+                type="date"
+                :error="errors.start_date"
+              />
+            </UFormGroup>
+
+            <UFormGroup :label="$t('classes.endDate')">
+              <UInput
+                v-model="form.end_date"
+                type="date"
+                :min="form.start_date"
+              />
+            </UFormGroup>
+          </div>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <UFormGroup :label="$t('classes.maxCapacity')" required>
+              <UInput
+                v-model.number="form.max_capacity"
+                type="number"
+                min="1"
+                :placeholder="$t('classes.enterCapacity')"
+                :error="errors.max_capacity"
+              />
+            </UFormGroup>
+
+            <UFormGroup :label="$t('classes.creditCost')" required>
+              <UInput
+                v-model.number="form.credit_cost"
+                type="number"
+                min="0"
+                step="0.5"
+                :placeholder="$t('classes.enterCreditCost')"
+                :error="errors.credit_cost"
+              />
+            </UFormGroup>
+          </div>
+
+          <UFormGroup :label="$t('classes.description')">
+            <UTextarea
+              v-model="form.description"
+              :placeholder="$t('classes.enterDescription')"
+              rows="3"
             />
           </UFormGroup>
 
-          <UFormGroup :label="$t('classes.endTime')" required>
-            <UInput
-              v-model="form.end_time"
-              type="time"
-              :error="errors.end_time"
+          <UFormGroup>
+            <UCheckbox
+              v-model="form.active"
+              :label="$t('common.active')"
             />
           </UFormGroup>
-        </div>
-
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <UFormGroup :label="$t('classes.startDate')" required>
-            <UInput
-              v-model="form.start_date"
-              type="date"
-              :error="errors.start_date"
-            />
-          </UFormGroup>
-
-          <UFormGroup :label="$t('classes.endDate')">
-            <UInput
-              v-model="form.end_date"
-              type="date"
-              :min="form.start_date"
-            />
-          </UFormGroup>
-        </div>
-
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <UFormGroup :label="$t('classes.maxCapacity')" required>
-            <UInput
-              v-model.number="form.max_capacity"
-              type="number"
-              min="1"
-              :placeholder="$t('classes.enterCapacity')"
-              :error="errors.max_capacity"
-            />
-          </UFormGroup>
-
-          <UFormGroup :label="$t('classes.creditCost')" required>
-            <UInput
-              v-model.number="form.credit_cost"
-              type="number"
-              min="0"
-              step="0.5"
-              :placeholder="$t('classes.enterCreditCost')"
-              :error="errors.credit_cost"
-            />
-          </UFormGroup>
-        </div>
-
-        <UFormGroup :label="$t('classes.description')">
-          <UTextarea
-            v-model="form.description"
-            :placeholder="$t('classes.enterDescription')"
-            rows="3"
-          />
-        </UFormGroup>
-
-        <UFormGroup>
-          <UCheckbox
-            v-model="form.active"
-            :label="$t('common.active')"
-          />
-        </UFormGroup>
-      </form>
+        </form>
+      </div>
 
       <template #footer>
         <div class="flex justify-end gap-2">

--- a/components/StudentForm.vue
+++ b/components/StudentForm.vue
@@ -1,105 +1,109 @@
 <template>
   <UModal v-model:open="modelValue">
     <template #content>
-      <UCard>
+      <UCard class="max-h-[90vh] flex flex-col">
         <template #header>
           <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
             {{ isEditing ? $t('student.editStudent') : $t('student.addStudent') }}
           </h3>
         </template>
 
-        <UForm :state="form" class="space-y-4" @submit="handleSubmit">
-          <UFormField
-            name="name"
-            :label="$t('student.name')"
-            required
-          >
-            <UInput
-              v-model="form.name"
-              class="w-full"
-              :placeholder="$t('student.namePlaceholder')"
-            />
-          </UFormField>
-
-          <UFormField
-            name="phone"
-            :label="$t('student.phone')"
-            required
-          >
-            <div class="flex gap-2">
-              <USelect
-                v-model="form.country_code"
-                class="w-32"
-                :items="countryCodeOptions"
-                :placeholder="$t('auth.countryCodePlaceholder')"
-              />
+        <div class="flex-1 overflow-y-auto">
+          <UForm :state="form" class="space-y-4" @submit="handleSubmit" ref="formRef">
+            <UFormField
+              name="name"
+              :label="$t('student.name')"
+              required
+            >
               <UInput
-                v-model="form.phone"
-                type="tel"
-                class="flex-1"
-                :placeholder="$t('student.phonePlaceholder')"
+                v-model="form.name"
+                class="w-full"
+                :placeholder="$t('student.namePlaceholder')"
               />
-            </div>
-          </UFormField>
+            </UFormField>
 
-          <UFormField
-            name="email"
-            :label="$t('student.email')"
-          >
-            <UInput
-              v-model="form.email"
-              type="email"
-              class="w-full"
-              :placeholder="$t('student.emailPlaceholder')"
+            <UFormField
+              name="phone"
+              :label="$t('student.phone')"
+              required
+            >
+              <div class="flex gap-2">
+                <USelect
+                  v-model="form.country_code"
+                  class="w-32"
+                  :items="countryCodeOptions"
+                  :placeholder="$t('auth.countryCodePlaceholder')"
+                />
+                <UInput
+                  v-model="form.phone"
+                  type="tel"
+                  class="flex-1"
+                  :placeholder="$t('student.phonePlaceholder')"
+                />
+              </div>
+            </UFormField>
+
+            <UFormField
+              name="email"
+              :label="$t('student.email')"
+            >
+              <UInput
+                v-model="form.email"
+                type="email"
+                class="w-full"
+                :placeholder="$t('student.emailPlaceholder')"
+              />
+            </UFormField>
+
+            <UFormField
+              name="address"
+              :label="$t('student.address')"
+            >
+              <UTextarea
+                v-model="form.address"
+                class="w-full"
+                :placeholder="$t('student.addressPlaceholder')"
+                :rows="3"
+              />
+            </UFormField>
+
+            <UFormField
+              name="credits"
+              :label="$t('student.credits')"
+            >
+              <UInput
+                v-model.number="form.credits"
+                type="number"
+                min="0"
+                class="w-full"
+                :placeholder="'0'"
+              />
+            </UFormField>
+
+            <UFormField
+              name="notes"
+              :label="$t('student.notes')"
+            >
+              <UTextarea
+                v-model="form.notes"
+                class="w-full"
+                :placeholder="$t('student.notesPlaceholder')"
+                :rows="3"
+              />
+            </UFormField>
+
+            <UAlert
+              v-if="error"
+              color="error"
+              variant="soft"
+              :title="$t('common.error')"
+              :description="error"
+              icon="i-heroicons-exclamation-triangle"
             />
-          </UFormField>
+          </UForm>
+        </div>
 
-          <UFormField
-            name="address"
-            :label="$t('student.address')"
-          >
-            <UTextarea
-              v-model="form.address"
-              class="w-full"
-              :placeholder="$t('student.addressPlaceholder')"
-              :rows="3"
-            />
-          </UFormField>
-
-          <UFormField
-            name="credits"
-            :label="$t('student.credits')"
-          >
-            <UInput
-              v-model.number="form.credits"
-              type="number"
-              min="0"
-              class="w-full"
-              :placeholder="'0'"
-            />
-          </UFormField>
-
-          <UFormField
-            name="notes"
-            :label="$t('student.notes')"
-          >
-            <UTextarea
-              v-model="form.notes"
-              class="w-full"
-              :placeholder="$t('student.notesPlaceholder')"
-              :rows="3"
-            />
-          </UFormField>
-
-          <UAlert
-            v-if="error"
-            color="error"
-            variant="soft"
-            :title="$t('common.error')"
-            :description="error"
-            icon="i-heroicons-exclamation-triangle"
-          />
-
+        <template #footer>
           <div class="flex justify-end gap-3">
             <UButton
               @click="handleCancel"
@@ -108,14 +112,14 @@
               {{ $t('common.cancel') }}
             </UButton>
             <UButton
-              type="submit"
+              @click="() => formRef?.submit()"
               :loading="submitting"
               color="primary"
             >
               {{ isEditing ? $t('common.save') : $t('common.add') }}
             </UButton>
           </div>
-        </UForm>
+        </template>
       </UCard>
     </template>
   </UModal>
@@ -135,6 +139,8 @@ interface Emits {
 const modelValue = defineModel<boolean>()
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
+
+const formRef = ref()
 
 const { studentSchema } = useStudentValidation()
 


### PR DESCRIPTION
Enable scrolling for modal forms and ensure action buttons are always visible on short screens.

Previously, modal dialogs would be cut off on screens with limited vertical space, preventing users from seeing all form fields or the submit/cancel buttons. This change introduces a maximum height for modals and makes their content area scrollable, while keeping the header and footer (with action buttons) fixed.

---
<a href="https://cursor.com/background-agent?bcId=bc-2002e7d5-f767-425d-89f8-564be66888b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2002e7d5-f767-425d-89f8-564be66888b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>