### PR TITLE
Translate form validation error messages

### DIFF
--- a/components/AddPackageToStudent.vue
+++ b/components/AddPackageToStudent.vue
@@ -195,7 +195,7 @@
 
 <script setup lang="ts">
 import type { PackageDocument } from '~/composables/usePouchDB'
-import type { AddPackageToStudentForm } from '~/composables/useStudentPackageValidation'
+import type { AddPackageToStudentForm } from '~/composables/useTranslatedValidation'
 import type { FormSubmitEvent } from '@nuxt/ui'
 
 interface Props {
@@ -225,7 +225,7 @@ const formRef = ref()
 const { t } = useI18n()
 const { packages, loading: packagesLoading } = usePackages()
 const { addPackageToStudent } = useStudentPackages()
-const { addPackageToStudentSchema } = useStudentPackageValidation()
+const { addPackageToStudentSchema } = useTranslatedValidation()
 
 const submitting = ref(false)
 

--- a/components/ClassTypeModal.vue
+++ b/components/ClassTypeModal.vue
@@ -70,10 +70,11 @@
 </template>
 
 <script setup lang="ts">
-import type { ClassTypeForm } from '~/composables/useClassTypeValidation'
+import type { ClassTypeForm } from '~/composables/useTranslatedValidation'
 import type { FormSubmitEvent } from '@nuxt/ui'
 
 const { t } = useI18n()
+const { classTypeSchema } = useTranslatedValidation()
 
 interface Props {
   open: boolean
@@ -94,7 +95,6 @@ const isOpen = computed({
 })
 
 const formRef = ref()
-const { classTypeSchema } = useClassTypeValidation()
 
 const saving = ref(false)
 

--- a/components/LocationModal.vue
+++ b/components/LocationModal.vue
@@ -83,10 +83,11 @@
 </template>
 
 <script setup lang="ts">
-import type { LocationForm } from '~/composables/useLocationValidation'
+import type { LocationForm } from '~/composables/useTranslatedValidation'
 import type { FormSubmitEvent } from '@nuxt/ui'
 
 const { t } = useI18n()
+const { locationSchema } = useTranslatedValidation()
 
 interface Props {
   open: boolean
@@ -107,7 +108,6 @@ const isOpen = computed({
 })
 
 const formRef = ref()
-const { locationSchema } = useLocationValidation()
 
 const saving = ref(false)
 

--- a/components/PackageForm.vue
+++ b/components/PackageForm.vue
@@ -117,7 +117,7 @@
 </template>
 
 <script setup lang="ts">
-import type { PackageForm } from '~/composables/usePackageValidation'
+import type { PackageForm } from '~/composables/useTranslatedValidation'
 import type { FormSubmitEvent } from '@nuxt/ui'
 
 interface Props {
@@ -133,7 +133,8 @@ const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 
 const formRef = ref()
-const { packageSchema } = usePackageValidation()
+const { t } = useI18n()
+const { packageSchema } = useTranslatedValidation()
 
 const submitting = ref(false)
 

--- a/components/ScheduleModal.vue
+++ b/components/ScheduleModal.vue
@@ -137,10 +137,11 @@
 </template>
 
 <script setup lang="ts">
-import type { ScheduleForm } from '~/composables/useScheduleValidation'
+import type { ScheduleForm } from '~/composables/useTranslatedValidation'
 import type { FormSubmitEvent } from '@nuxt/ui'
 
 const { t } = useI18n()
+const { scheduleSchema } = useTranslatedValidation()
 
 interface Props {
   open: boolean
@@ -161,7 +162,6 @@ const isOpen = computed({
 })
 
 const formRef = ref()
-const { scheduleSchema } = useScheduleValidation()
 
 const saving = ref(false)
 

--- a/components/StudentForm.vue
+++ b/components/StudentForm.vue
@@ -113,7 +113,7 @@
 </template>
 
 <script setup lang="ts">
-import type { StudentForm } from '~/composables/useStudentValidation'
+import type { StudentForm } from '~/composables/useTranslatedValidation'
 import type { FormSubmitEvent } from '@nuxt/ui'
 
 interface Props {
@@ -129,7 +129,8 @@ const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 
 const formRef = ref()
-const { studentSchema } = useStudentValidation()
+const { t } = useI18n()
+const { studentSchema } = useTranslatedValidation()
 
 const submitting = ref(false)
 

--- a/composables/useAuthValidation.ts
+++ b/composables/useAuthValidation.ts
@@ -3,43 +3,43 @@ import { z } from 'zod'
 // Login form validation schema
 export const loginSchema = z.object({
   username: z.string()
-    .min(1, 'Username is required')
-    .min(3, 'Username must be at least 3 characters')
-    .max(50, 'Username must be less than 50 characters'),
+    .min(1, 'validation.username.required')
+    .min(3, 'validation.username.minLength')
+    .max(50, 'validation.username.maxLength'),
   password: z.string()
-    .min(1, 'Password is required')
-    .min(6, 'Password must be at least 6 characters')
+    .min(1, 'validation.password.required')
+    .min(6, 'validation.password.minLength')
 })
 
 // Registration form validation schema
 export const registerSchema = z.object({
   display_name: z.string()
-    .min(1, 'Display name is required')
-    .max(100, 'Display name must be less than 100 characters'),
+    .min(1, 'validation.displayName.required')
+    .max(100, 'validation.displayName.maxLength'),
   username: z.string()
-    .min(3, 'Username must be at least 3 characters')
-    .max(50, 'Username must be less than 50 characters')
-    .regex(/^[a-zA-Z0-9_]+$/, 'Username can only contain letters, numbers, and underscores'),
+    .min(3, 'validation.username.minLength')
+    .max(50, 'validation.username.maxLength')
+    .regex(/^[a-zA-Z0-9_]+$/, 'validation.username.format'),
   email: z.string()
-    .email('Please enter a valid email address')
+    .email('validation.email.invalid')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
   country_code: z.string()
-    .min(1, 'Country code is required'),
+    .min(1, 'validation.countryCode.required'),
   phone: z.string()
-    .min(1, 'Phone number is required')
-    .regex(/^[0-9+\-\s()]+$/, 'Please enter a valid phone number'),
+    .min(1, 'validation.phone.required')
+    .regex(/^[0-9+\-\s()]+$/, 'validation.phone.invalid'),
   password: z.string()
-    .min(6, 'Password must be at least 6 characters')
-    .max(128, 'Password must be less than 128 characters'),
+    .min(6, 'validation.password.minLength')
+    .max(128, 'validation.password.maxLength'),
   confirmPassword: z.string()
-    .min(1, 'Please confirm your password'),
+    .min(1, 'validation.password.confirm'),
   language: z.enum(['en', 'zh-Hant'], {
-    errorMap: () => ({ message: 'Please select a valid language' })
+    errorMap: () => ({ message: 'validation.language.invalid' })
   })
 }).refine((data) => data.password === data.confirmPassword, {
-  message: "Passwords don't match",
+  message: 'validation.password.mismatch',
   path: ["confirmPassword"]
 })
 

--- a/composables/useClassTypeValidation.ts
+++ b/composables/useClassTypeValidation.ts
@@ -3,16 +3,16 @@ import { z } from 'zod'
 // Class type form validation schema
 export const classTypeSchema = z.object({
   name: z.string()
-    .min(1, 'Name is required')
-    .max(100, 'Name must be less than 100 characters'),
+    .min(1, 'validation.classTypeName.required')
+    .max(100, 'validation.classTypeName.maxLength'),
   description: z.string()
-    .max(500, 'Description must be less than 500 characters')
+    .max(500, 'validation.description.maxLength')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
   default_credit_cost: z.number()
-    .min(0, 'Default credit cost cannot be negative')
-    .max(1000, 'Default credit cost cannot exceed 1000'),
+    .min(0, 'validation.defaultCreditCost.negative')
+    .max(1000, 'validation.defaultCreditCost.maxExceeded'),
   active: z.boolean()
 })
 

--- a/composables/useClassValidation.ts
+++ b/composables/useClassValidation.ts
@@ -3,41 +3,41 @@ import { z } from 'zod'
 // Class form validation schema
 export const classSchema = z.object({
   name: z.string()
-    .min(1, 'Class name is required')
-    .min(2, 'Class name must be at least 2 characters')
-    .max(100, 'Class name must be less than 100 characters'),
+    .min(1, 'validation.className.required')
+    .min(2, 'validation.className.minLength')
+    .max(100, 'validation.className.maxLength'),
   description: z.string()
-    .max(500, 'Description must be less than 500 characters')
+    .max(500, 'validation.description.maxLength')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
   class_type_id: z.string()
-    .min(1, 'Class type is required'),
+    .min(1, 'validation.classType.required'),
   location_id: z.string()
-    .min(1, 'Location is required'),
+    .min(1, 'validation.location.required'),
   max_students: z.number()
-    .min(1, 'Maximum students must be at least 1')
-    .max(50, 'Maximum students cannot exceed 50'),
+    .min(1, 'validation.maxStudents.min')
+    .max(50, 'validation.maxStudents.maxExceeded'),
   price: z.number()
-    .min(0, 'Price cannot be negative')
-    .max(99999, 'Price cannot exceed 99999'),
+    .min(0, 'validation.price.negative')
+    .max(99999, 'validation.price.maxExceededSimple'),
   active: z.boolean().default(true)
 })
 
 // Class Type form validation schema
 export const classTypeSchema = z.object({
   name: z.string()
-    .min(1, 'Class type name is required')
-    .min(2, 'Class type name must be at least 2 characters')
-    .max(100, 'Class type name must be less than 100 characters'),
+    .min(1, 'validation.classTypeName.required')
+    .min(2, 'validation.classTypeName.minLength')
+    .max(100, 'validation.classTypeName.maxLength'),
   description: z.string()
-    .max(500, 'Description must be less than 500 characters')
+    .max(500, 'validation.description.maxLength')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
   duration_minutes: z.number()
-    .min(15, 'Duration must be at least 15 minutes')
-    .max(480, 'Duration cannot exceed 8 hours'),
+    .min(15, 'validation.durationMinutes.min')
+    .max(480, 'validation.durationMinutes.maxExceeded'),
   active: z.boolean().default(true)
 })
 

--- a/composables/useLocationValidation.ts
+++ b/composables/useLocationValidation.ts
@@ -3,21 +3,21 @@ import { z } from 'zod'
 // Location form validation schema
 export const locationSchema = z.object({
   name: z.string()
-    .min(1, 'Name is required')
-    .max(100, 'Name must be less than 100 characters'),
+    .min(1, 'validation.name.required')
+    .max(100, 'validation.name.maxLength'),
   address: z.string()
-    .min(1, 'Address is required')
-    .max(500, 'Address must be less than 500 characters'),
+    .min(1, 'validation.address.required')
+    .max(500, 'validation.address.maxLength'),
   phone: z.string()
-    .min(1, 'Phone number is required')
-    .regex(/^[0-9+\-\s()]+$/, 'Please enter a valid phone number'),
+    .min(1, 'validation.phone.required')
+    .regex(/^[0-9+\-\s()]+$/, 'validation.phone.invalid'),
   email: z.string()
-    .email('Please enter a valid email address')
+    .email('validation.email.invalid')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
   website: z.string()
-    .url('Please enter a valid URL')
+    .url('validation.website.invalid')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),

--- a/composables/usePackageValidation.ts
+++ b/composables/usePackageValidation.ts
@@ -3,22 +3,22 @@ import { z } from 'zod'
 // Package form validation schema
 export const packageSchema = z.object({
   name: z.string()
-    .min(1, 'Name is required')
-    .max(100, 'Name must be less than 100 characters'),
+    .min(1, 'validation.name.required')
+    .max(100, 'validation.name.maxLength'),
   description: z.string()
-    .max(500, 'Description must be less than 500 characters')
+    .max(500, 'validation.description.maxLength')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
   price: z.number()
-    .min(0, 'Price cannot be negative')
-    .max(99999.99, 'Price cannot exceed $99,999.99'),
+    .min(0, 'validation.price.negative')
+    .max(99999.99, 'validation.price.maxExceeded'),
   credits: z.number()
-    .min(1, 'Credits must be at least 1')
-    .max(99999, 'Credits cannot exceed 99999'),
+    .min(1, 'validation.packageCredits.min')
+    .max(99999, 'validation.packageCredits.maxExceeded'),
   duration_days: z.number()
-    .min(1, 'Duration must be at least 1 day')
-    .max(3650, 'Duration cannot exceed 10 years'),
+    .min(1, 'validation.duration.min')
+    .max(3650, 'validation.duration.maxExceeded'),
   active: z.boolean()
 })
 

--- a/composables/useScheduleValidation.ts
+++ b/composables/useScheduleValidation.ts
@@ -3,31 +3,31 @@ import { z } from 'zod'
 // Schedule form validation schema
 export const scheduleSchema = z.object({
   class_type_id: z.string()
-    .min(1, 'Class type is required'),
+    .min(1, 'validation.classType.required'),
   location_id: z.string()
-    .min(1, 'Location is required'),
+    .min(1, 'validation.location.required'),
   weekly_days: z.array(z.string())
-    .min(1, 'At least one day must be selected'),
+    .min(1, 'validation.weeklyDays.required'),
   start_time: z.string()
-    .min(1, 'Start time is required')
-    .regex(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, 'Please enter a valid time'),
+    .min(1, 'validation.startTime.required')
+    .regex(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, 'validation.startTime.invalid'),
   end_time: z.string()
-    .min(1, 'End time is required')
-    .regex(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, 'Please enter a valid time'),
+    .min(1, 'validation.endTime.required')
+    .regex(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, 'validation.endTime.invalid'),
   start_date: z.string()
-    .min(1, 'Start date is required'),
+    .min(1, 'validation.startDate.required'),
   end_date: z.string()
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
   max_capacity: z.number()
-    .min(1, 'Maximum capacity must be at least 1')
-    .max(1000, 'Maximum capacity cannot exceed 1000'),
+    .min(1, 'validation.maxCapacity.min')
+    .max(1000, 'validation.maxCapacity.maxExceeded'),
   credit_cost: z.number()
-    .min(0, 'Credit cost cannot be negative')
-    .max(1000, 'Credit cost cannot exceed 1000'),
+    .min(0, 'validation.creditCost.negative')
+    .max(1000, 'validation.creditCost.maxExceeded'),
   description: z.string()
-    .max(1000, 'Description must be less than 1000 characters')
+    .max(1000, 'validation.notes.maxLength')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
@@ -38,7 +38,7 @@ export const scheduleSchema = z.object({
   }
   return true
 }, {
-  message: "End time must be after start time",
+  message: 'validation.endTimeAfterStart',
   path: ["end_time"]
 }).refine((data) => {
   if (data.start_date && data.end_date && data.end_date !== '') {
@@ -46,7 +46,7 @@ export const scheduleSchema = z.object({
   }
   return true
 }, {
-  message: "End date must be after or equal to start date",
+  message: 'validation.endDate.afterStart',
   path: ["end_date"]
 })
 

--- a/composables/useStudentPackageValidation.ts
+++ b/composables/useStudentPackageValidation.ts
@@ -3,39 +3,39 @@ import { z } from 'zod'
 // Add package to student form validation schema
 export const addPackageToStudentSchema = z.object({
   package_type: z.enum(['existing', 'custom'], {
-    errorMap: () => ({ message: 'Please select a package type' })
+    errorMap: () => ({ message: 'validation.packageType.required' })
   }),
   package_id: z.string()
-    .min(1, 'Please select a package')
+    .min(1, 'validation.package.required')
     .optional()
     .or(z.literal('')),
   custom_price: z.number()
-    .min(0, 'Custom price cannot be negative')
-    .max(99999.99, 'Custom price cannot exceed $99,999.99')
+    .min(0, 'validation.customPrice.negative')
+    .max(99999.99, 'validation.customPrice.maxExceeded')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
   notes: z.string()
-    .max(1000, 'Notes must be less than 1000 characters')
+    .max(1000, 'validation.notes.maxLength')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
   // Custom package fields
   custom_package_price: z.number()
-    .min(0, 'Price cannot be negative')
-    .max(99999.99, 'Price cannot exceed $99,999.99')
+    .min(0, 'validation.customPrice.negative')
+    .max(99999.99, 'validation.customPrice.maxExceeded')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
   custom_package_credits: z.number()
-    .min(1, 'Credits must be at least 1')
-    .max(99999, 'Credits cannot exceed 99999')
+    .min(1, 'validation.customCredits.min')
+    .max(99999, 'validation.customCredits.maxExceeded')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
   custom_package_duration: z.number()
-    .min(1, 'Duration must be at least 1 day')
-    .max(3650, 'Duration cannot exceed 10 years')
+    .min(1, 'validation.customDuration.min')
+    .max(3650, 'validation.customDuration.maxExceeded')
     .optional()
     .or(z.literal(''))
     .transform(val => val || '')
@@ -45,7 +45,7 @@ export const addPackageToStudentSchema = z.object({
   }
   return true
 }, {
-  message: "Please select a package",
+  message: 'validation.package.required',
   path: ["package_id"]
 }).refine((data) => {
   if (data.package_type === 'custom') {
@@ -53,7 +53,7 @@ export const addPackageToStudentSchema = z.object({
   }
   return true
 }, {
-  message: "Price is required for custom packages",
+  message: 'validation.customPrice.required',
   path: ["custom_package_price"]
 }).refine((data) => {
   if (data.package_type === 'custom') {
@@ -61,7 +61,7 @@ export const addPackageToStudentSchema = z.object({
   }
   return true
 }, {
-  message: "Credits are required for custom packages",
+  message: 'validation.customCredits.required',
   path: ["custom_package_credits"]
 }).refine((data) => {
   if (data.package_type === 'custom') {
@@ -69,7 +69,7 @@ export const addPackageToStudentSchema = z.object({
   }
   return true
 }, {
-  message: "Duration is required for custom packages",
+  message: 'validation.customDuration.required',
   path: ["custom_package_duration"]
 })
 

--- a/composables/useStudentValidation.ts
+++ b/composables/useStudentValidation.ts
@@ -3,28 +3,28 @@ import { z } from 'zod'
 // Student form validation schema
 export const studentSchema = z.object({
   name: z.string()
-    .min(1, 'Name is required')
-    .max(100, 'Name must be less than 100 characters'),
+    .min(1, 'validation.name.required')
+    .max(100, 'validation.name.maxLength'),
   phone: z.string()
-    .min(1, 'Phone number is required')
-    .regex(/^[0-9+\-\s()]+$/, 'Please enter a valid phone number'),
+    .min(1, 'validation.phone.required')
+    .regex(/^[0-9+\-\s()]+$/, 'validation.phone.invalid'),
   country_code: z.string()
-    .min(1, 'Country code is required'),
+    .min(1, 'validation.countryCode.required'),
   email: z.string()
-    .email('Please enter a valid email address')
+    .email('validation.email.invalid')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
   address: z.string()
-    .max(500, 'Address must be less than 500 characters')
+    .max(500, 'validation.address.maxLength')
     .optional()
     .or(z.literal(''))
     .transform(val => val || ''),
   credits: z.number()
-    .min(0, 'Credits cannot be negative')
-    .max(99999, 'Credits cannot exceed 99999'),
+    .min(0, 'validation.credits.negative')
+    .max(99999, 'validation.credits.maxExceeded'),
   notes: z.string()
-    .max(1000, 'Notes must be less than 1000 characters')
+    .max(1000, 'validation.notes.maxLength')
     .optional()
     .or(z.literal(''))
     .transform(val => val || '')

--- a/composables/useTranslatedValidation.ts
+++ b/composables/useTranslatedValidation.ts
@@ -1,0 +1,400 @@
+import { z } from 'zod'
+
+// Create base schemas without translations for type inference
+const baseLoginSchema = z.object({
+  username: z.string().min(1).min(3).max(50),
+  password: z.string().min(1).min(6)
+})
+
+const baseRegisterSchema = z.object({
+  display_name: z.string().min(1).max(100),
+  username: z.string().min(3).max(50).regex(/^[a-zA-Z0-9_]+$/),
+  email: z.string().email().optional().or(z.literal('')).transform(val => val || ''),
+  country_code: z.string().min(1),
+  phone: z.string().min(1).regex(/^[0-9+\-\s()]+$/),
+  password: z.string().min(6).max(128),
+  confirmPassword: z.string().min(1),
+  language: z.enum(['en', 'zh-Hant'])
+}).refine((data) => data.password === data.confirmPassword, {
+  path: ["confirmPassword"]
+})
+
+const baseStudentSchema = z.object({
+  name: z.string().min(1).max(100),
+  phone: z.string().min(1).regex(/^[0-9+\-\s()]+$/),
+  country_code: z.string().min(1),
+  email: z.string().email().optional().or(z.literal('')).transform(val => val || ''),
+  address: z.string().max(500).optional().or(z.literal('')).transform(val => val || ''),
+  credits: z.number().min(0).max(99999),
+  notes: z.string().max(1000).optional().or(z.literal('')).transform(val => val || '')
+})
+
+const basePackageSchema = z.object({
+  name: z.string().min(1).max(100),
+  description: z.string().max(500).optional().or(z.literal('')).transform(val => val || ''),
+  price: z.number().min(0).max(99999.99),
+  credits: z.number().min(1).max(99999),
+  duration_days: z.number().min(1).max(3650),
+  active: z.boolean()
+})
+
+const baseScheduleSchema = z.object({
+  class_type_id: z.string().min(1),
+  location_id: z.string().min(1),
+  weekly_days: z.array(z.string()).min(1),
+  start_time: z.string().min(1).regex(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/),
+  end_time: z.string().min(1).regex(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/),
+  start_date: z.string().min(1),
+  end_date: z.string().optional().or(z.literal('')).transform(val => val || ''),
+  max_capacity: z.number().min(1).max(1000),
+  credit_cost: z.number().min(0).max(1000),
+  description: z.string().max(1000).optional().or(z.literal('')).transform(val => val || ''),
+  active: z.boolean()
+})
+
+const baseClassSchema = z.object({
+  name: z.string().min(1).min(2).max(100),
+  description: z.string().max(500).optional().or(z.literal('')).transform(val => val || ''),
+  class_type_id: z.string().min(1),
+  location_id: z.string().min(1),
+  max_students: z.number().min(1).max(50),
+  price: z.number().min(0).max(99999),
+  active: z.boolean().default(true)
+})
+
+const baseClassTypeSchema = z.object({
+  name: z.string().min(1).min(2).max(100),
+  description: z.string().max(500).optional().or(z.literal('')).transform(val => val || ''),
+  duration_minutes: z.number().min(15).max(480),
+  active: z.boolean().default(true)
+})
+
+const baseLocationSchema = z.object({
+  name: z.string().min(1).max(100),
+  address: z.string().min(1).max(500),
+  phone: z.string().min(1).regex(/^[0-9+\-\s()]+$/),
+  email: z.string().email().optional().or(z.literal('')).transform(val => val || ''),
+  website: z.string().url().optional().or(z.literal('')).transform(val => val || ''),
+  active: z.boolean()
+})
+
+const baseAddPackageToStudentSchema = z.object({
+  package_type: z.enum(['existing', 'custom']),
+  package_id: z.string().min(1).optional().or(z.literal('')),
+  custom_price: z.number().min(0).max(99999.99).optional().or(z.literal('')).transform(val => val || ''),
+  notes: z.string().max(1000).optional().or(z.literal('')).transform(val => val || ''),
+  custom_package_price: z.number().min(0).max(99999.99).optional().or(z.literal('')).transform(val => val || ''),
+  custom_package_credits: z.number().min(1).max(99999).optional().or(z.literal('')).transform(val => val || ''),
+  custom_package_duration: z.number().min(1).max(3650).optional().or(z.literal('')).transform(val => val || '')
+})
+
+// Type exports
+export type LoginForm = z.infer<typeof baseLoginSchema>
+export type RegisterForm = z.infer<typeof baseRegisterSchema>
+export type StudentForm = z.infer<typeof baseStudentSchema>
+export type PackageForm = z.infer<typeof basePackageSchema>
+export type ScheduleForm = z.infer<typeof baseScheduleSchema>
+export type ClassForm = z.infer<typeof baseClassSchema>
+export type ClassTypeForm = z.infer<typeof baseClassTypeSchema>
+export type LocationForm = z.infer<typeof baseLocationSchema>
+export type AddPackageToStudentForm = z.infer<typeof baseAddPackageToStudentSchema>
+
+// Create validation schemas with translated error messages
+export const useTranslatedValidation = () => {
+  const { t } = useI18n()
+
+  // Login form validation schema
+  const loginSchema = z.object({
+    username: z.string()
+      .min(1, t('validation.username.required'))
+      .min(3, t('validation.username.minLength'))
+      .max(50, t('validation.username.maxLength')),
+    password: z.string()
+      .min(1, t('validation.password.required'))
+      .min(6, t('validation.password.minLength'))
+  })
+
+  // Registration form validation schema
+  const registerSchema = z.object({
+    display_name: z.string()
+      .min(1, t('validation.displayName.required'))
+      .max(100, t('validation.displayName.maxLength')),
+    username: z.string()
+      .min(3, t('validation.username.minLength'))
+      .max(50, t('validation.username.maxLength'))
+      .regex(/^[a-zA-Z0-9_]+$/, t('validation.username.format')),
+    email: z.string()
+      .email(t('validation.email.invalid'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    country_code: z.string()
+      .min(1, t('validation.countryCode.required')),
+    phone: z.string()
+      .min(1, t('validation.phone.required'))
+      .regex(/^[0-9+\-\s()]+$/, t('validation.phone.invalid')),
+    password: z.string()
+      .min(6, t('validation.password.minLength'))
+      .max(128, t('validation.password.maxLength')),
+    confirmPassword: z.string()
+      .min(1, t('validation.password.confirm')),
+    language: z.enum(['en', 'zh-Hant'], {
+      errorMap: () => ({ message: t('validation.language.invalid') })
+    })
+  }).refine((data) => data.password === data.confirmPassword, {
+    message: t('validation.password.mismatch'),
+    path: ["confirmPassword"]
+  })
+
+  // Student form validation schema
+  const studentSchema = z.object({
+    name: z.string()
+      .min(1, t('validation.name.required'))
+      .max(100, t('validation.name.maxLength')),
+    phone: z.string()
+      .min(1, t('validation.phone.required'))
+      .regex(/^[0-9+\-\s()]+$/, t('validation.phone.invalid')),
+    country_code: z.string()
+      .min(1, t('validation.countryCode.required')),
+    email: z.string()
+      .email(t('validation.email.invalid'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    address: z.string()
+      .max(500, t('validation.address.maxLength'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    credits: z.number()
+      .min(0, t('validation.credits.negative'))
+      .max(99999, t('validation.credits.maxExceeded')),
+    notes: z.string()
+      .max(1000, t('validation.notes.maxLength'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || '')
+  })
+
+  // Package form validation schema
+  const packageSchema = z.object({
+    name: z.string()
+      .min(1, t('validation.name.required'))
+      .max(100, t('validation.name.maxLength')),
+    description: z.string()
+      .max(500, t('validation.description.maxLength'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    price: z.number()
+      .min(0, t('validation.price.negative'))
+      .max(99999.99, t('validation.price.maxExceeded')),
+    credits: z.number()
+      .min(1, t('validation.packageCredits.min'))
+      .max(99999, t('validation.packageCredits.maxExceeded')),
+    duration_days: z.number()
+      .min(1, t('validation.duration.min'))
+      .max(3650, t('validation.duration.maxExceeded')),
+    active: z.boolean()
+  })
+
+  // Schedule form validation schema
+  const scheduleSchema = z.object({
+    class_type_id: z.string()
+      .min(1, t('validation.classType.required')),
+    location_id: z.string()
+      .min(1, t('validation.location.required')),
+    weekly_days: z.array(z.string())
+      .min(1, t('validation.weeklyDays.required')),
+    start_time: z.string()
+      .min(1, t('validation.startTime.required'))
+      .regex(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, t('validation.startTime.invalid')),
+    end_time: z.string()
+      .min(1, t('validation.endTime.required'))
+      .regex(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, t('validation.endTime.invalid')),
+    start_date: z.string()
+      .min(1, t('validation.startDate.required')),
+    end_date: z.string()
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    max_capacity: z.number()
+      .min(1, t('validation.maxCapacity.min'))
+      .max(1000, t('validation.maxCapacity.maxExceeded')),
+    credit_cost: z.number()
+      .min(0, t('validation.creditCost.negative'))
+      .max(1000, t('validation.creditCost.maxExceeded')),
+    description: z.string()
+      .max(1000, t('validation.notes.maxLength'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    active: z.boolean()
+  }).refine((data) => {
+    if (data.start_time && data.end_time) {
+      return data.start_time < data.end_time
+    }
+    return true
+  }, {
+    message: t('validation.endTimeAfterStart'),
+    path: ["end_time"]
+  }).refine((data) => {
+    if (data.start_date && data.end_date && data.end_date !== '') {
+      return new Date(data.start_date) <= new Date(data.end_date)
+    }
+    return true
+  }, {
+    message: t('validation.endDate.afterStart'),
+    path: ["end_date"]
+  })
+
+  // Class form validation schema
+  const classSchema = z.object({
+    name: z.string()
+      .min(1, t('validation.className.required'))
+      .min(2, t('validation.className.minLength'))
+      .max(100, t('validation.className.maxLength')),
+    description: z.string()
+      .max(500, t('validation.description.maxLength'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    class_type_id: z.string()
+      .min(1, t('validation.classType.required')),
+    location_id: z.string()
+      .min(1, t('validation.location.required')),
+    max_students: z.number()
+      .min(1, t('validation.maxStudents.min'))
+      .max(50, t('validation.maxStudents.maxExceeded')),
+    price: z.number()
+      .min(0, t('validation.price.negative'))
+      .max(99999, t('validation.price.maxExceededSimple')),
+    active: z.boolean().default(true)
+  })
+
+  // Class Type form validation schema
+  const classTypeSchema = z.object({
+    name: z.string()
+      .min(1, t('validation.classTypeName.required'))
+      .min(2, t('validation.classTypeName.minLength'))
+      .max(100, t('validation.classTypeName.maxLength')),
+    description: z.string()
+      .max(500, t('validation.description.maxLength'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    duration_minutes: z.number()
+      .min(15, t('validation.durationMinutes.min'))
+      .max(480, t('validation.durationMinutes.maxExceeded')),
+    active: z.boolean().default(true)
+  })
+
+  // Location form validation schema
+  const locationSchema = z.object({
+    name: z.string()
+      .min(1, t('validation.name.required'))
+      .max(100, t('validation.name.maxLength')),
+    address: z.string()
+      .min(1, t('validation.address.required'))
+      .max(500, t('validation.address.maxLength')),
+    phone: z.string()
+      .min(1, t('validation.phone.required'))
+      .regex(/^[0-9+\-\s()]+$/, t('validation.phone.invalid')),
+    email: z.string()
+      .email(t('validation.email.invalid'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    website: z.string()
+      .url(t('validation.website.invalid'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    active: z.boolean()
+  })
+
+  // Add package to student form validation schema
+  const addPackageToStudentSchema = z.object({
+    package_type: z.enum(['existing', 'custom'], {
+      errorMap: () => ({ message: t('validation.packageType.required') })
+    }),
+    package_id: z.string()
+      .min(1, t('validation.package.required'))
+      .optional()
+      .or(z.literal('')),
+    custom_price: z.number()
+      .min(0, t('validation.customPrice.negative'))
+      .max(99999.99, t('validation.customPrice.maxExceeded'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    notes: z.string()
+      .max(1000, t('validation.notes.maxLength'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    // Custom package fields
+    custom_package_price: z.number()
+      .min(0, t('validation.customPrice.negative'))
+      .max(99999.99, t('validation.customPrice.maxExceeded'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    custom_package_credits: z.number()
+      .min(1, t('validation.customCredits.min'))
+      .max(99999, t('validation.customCredits.maxExceeded'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || ''),
+    custom_package_duration: z.number()
+      .min(1, t('validation.customDuration.min'))
+      .max(3650, t('validation.customDuration.maxExceeded'))
+      .optional()
+      .or(z.literal(''))
+      .transform(val => val || '')
+  }).refine((data) => {
+    if (data.package_type === 'existing') {
+      return data.package_id && data.package_id.length > 0
+    }
+    return true
+  }, {
+    message: t('validation.package.required'),
+    path: ["package_id"]
+  }).refine((data) => {
+    if (data.package_type === 'custom') {
+      return data.custom_package_price && data.custom_package_price > 0
+    }
+    return true
+  }, {
+    message: t('validation.customPrice.required'),
+    path: ["custom_package_price"]
+  }).refine((data) => {
+    if (data.package_type === 'custom') {
+      return data.custom_package_credits && data.custom_package_credits > 0
+    }
+    return true
+  }, {
+    message: t('validation.customCredits.required'),
+    path: ["custom_package_credits"]
+  }).refine((data) => {
+    if (data.package_type === 'custom') {
+      return data.custom_package_duration && data.custom_package_duration > 0
+    }
+    return true
+  }, {
+    message: t('validation.customDuration.required'),
+    path: ["custom_package_duration"]
+  })
+
+  return {
+    loginSchema,
+    registerSchema,
+    studentSchema,
+    packageSchema,
+    scheduleSchema,
+    classSchema,
+    classTypeSchema,
+    locationSchema,
+    addPackageToStudentSchema
+  }
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -266,7 +266,145 @@
     "positiveNumber": "{field} must be a positive number",
     "invalidEmail": "Invalid email address",
     "invalidUrl": "Invalid URL",
-    "endTimeAfterStart": "End time must be after start time"
+    "endTimeAfterStart": "End time must be after start time",
+    "username": {
+      "required": "Username is required",
+      "minLength": "Username must be at least 3 characters",
+      "maxLength": "Username must be less than 50 characters",
+      "format": "Username can only contain letters, numbers, and underscores"
+    },
+    "password": {
+      "required": "Password is required",
+      "minLength": "Password must be at least 6 characters",
+      "maxLength": "Password must be less than 128 characters",
+      "confirm": "Please confirm your password",
+      "mismatch": "Passwords don't match"
+    },
+    "displayName": {
+      "required": "Display name is required",
+      "maxLength": "Display name must be less than 100 characters"
+    },
+    "email": {
+      "invalid": "Please enter a valid email address"
+    },
+    "countryCode": {
+      "required": "Country code is required"
+    },
+    "phone": {
+      "required": "Phone number is required",
+      "invalid": "Please enter a valid phone number"
+    },
+    "language": {
+      "invalid": "Please select a valid language"
+    },
+    "name": {
+      "required": "Name is required",
+      "maxLength": "Name must be less than 100 characters"
+    },
+    "address": {
+      "required": "Address is required",
+      "maxLength": "Address must be less than 500 characters"
+    },
+    "credits": {
+      "negative": "Credits cannot be negative",
+      "maxExceeded": "Credits cannot exceed 99999"
+    },
+    "notes": {
+      "maxLength": "Notes must be less than 1000 characters"
+    },
+    "description": {
+      "maxLength": "Description must be less than 500 characters"
+    },
+    "price": {
+      "negative": "Price cannot be negative",
+      "maxExceeded": "Price cannot exceed $99,999.99",
+      "maxExceededSimple": "Price cannot exceed 99999"
+    },
+    "packageCredits": {
+      "min": "Credits must be at least 1",
+      "maxExceeded": "Credits cannot exceed 99999"
+    },
+    "duration": {
+      "min": "Duration must be at least 1 day",
+      "maxExceeded": "Duration cannot exceed 10 years"
+    },
+    "classType": {
+      "required": "Class type is required"
+    },
+    "location": {
+      "required": "Location is required"
+    },
+    "weeklyDays": {
+      "required": "At least one day must be selected"
+    },
+    "startTime": {
+      "required": "Start time is required",
+      "invalid": "Please enter a valid time"
+    },
+    "endTime": {
+      "required": "End time is required",
+      "invalid": "Please enter a valid time"
+    },
+    "startDate": {
+      "required": "Start date is required"
+    },
+    "endDate": {
+      "afterStart": "End date must be after or equal to start date"
+    },
+    "maxCapacity": {
+      "min": "Maximum capacity must be at least 1",
+      "maxExceeded": "Maximum capacity cannot exceed 1000"
+    },
+    "creditCost": {
+      "negative": "Credit cost cannot be negative",
+      "maxExceeded": "Credit cost cannot exceed 1000"
+    },
+    "className": {
+      "required": "Class name is required",
+      "minLength": "Class name must be at least 2 characters",
+      "maxLength": "Class name must be less than 100 characters"
+    },
+    "classTypeName": {
+      "required": "Class type name is required",
+      "minLength": "Class type name must be at least 2 characters",
+      "maxLength": "Class type name must be less than 100 characters"
+    },
+    "durationMinutes": {
+      "min": "Duration must be at least 15 minutes",
+      "maxExceeded": "Duration cannot exceed 8 hours"
+    },
+    "maxStudents": {
+      "min": "Maximum students must be at least 1",
+      "maxExceeded": "Maximum students cannot exceed 50"
+    },
+    "website": {
+      "invalid": "Please enter a valid URL"
+    },
+    "packageType": {
+      "required": "Please select a package type"
+    },
+    "package": {
+      "required": "Please select a package"
+    },
+    "customPrice": {
+      "negative": "Custom price cannot be negative",
+      "maxExceeded": "Custom price cannot exceed $99,999.99",
+      "required": "Price is required for custom packages"
+    },
+    "customCredits": {
+      "min": "Credits must be at least 1",
+      "maxExceeded": "Credits cannot exceed 99999",
+      "required": "Credits are required for custom packages"
+    },
+    "customDuration": {
+      "min": "Duration must be at least 1 day",
+      "maxExceeded": "Duration cannot exceed 10 years",
+      "required": "Duration is required for custom packages"
+    },
+    "defaultCreditCost": {
+      "negative": "Default credit cost cannot be negative",
+      "maxExceeded": "Default credit cost cannot exceed 1000"
+    }
   },
   "common": {
     "save": "Save",

--- a/i18n/locales/zh-Hant.json
+++ b/i18n/locales/zh-Hant.json
@@ -266,7 +266,145 @@
     "positiveNumber": "{field} 必須為正數",
     "invalidEmail": "無效的電子郵件地址",
     "invalidUrl": "無效的網址",
-    "endTimeAfterStart": "結束時間必須晚於開始時間"
+    "endTimeAfterStart": "結束時間必須晚於開始時間",
+    "username": {
+      "required": "用戶名為必填項",
+      "minLength": "用戶名至少需要3個字符",
+      "maxLength": "用戶名不能超過50個字符",
+      "format": "用戶名只能包含字母、數字和下劃線"
+    },
+    "password": {
+      "required": "密碼為必填項",
+      "minLength": "密碼至少需要6個字符",
+      "maxLength": "密碼不能超過128個字符",
+      "confirm": "請確認您的密碼",
+      "mismatch": "密碼不匹配"
+    },
+    "displayName": {
+      "required": "顯示名稱為必填項",
+      "maxLength": "顯示名稱不能超過100個字符"
+    },
+    "email": {
+      "invalid": "請輸入有效的電子郵件地址"
+    },
+    "countryCode": {
+      "required": "國家代碼為必填項"
+    },
+    "phone": {
+      "required": "電話號碼為必填項",
+      "invalid": "請輸入有效的電話號碼"
+    },
+    "language": {
+      "invalid": "請選擇有效的語言"
+    },
+    "name": {
+      "required": "名稱為必填項",
+      "maxLength": "名稱不能超過100個字符"
+    },
+    "address": {
+      "required": "地址為必填項",
+      "maxLength": "地址不能超過500個字符"
+    },
+    "credits": {
+      "negative": "學分不能為負數",
+      "maxExceeded": "學分不能超過99999"
+    },
+    "notes": {
+      "maxLength": "備註不能超過1000個字符"
+    },
+    "description": {
+      "maxLength": "描述不能超過500個字符"
+    },
+    "price": {
+      "negative": "價格不能為負數",
+      "maxExceeded": "價格不能超過$99,999.99",
+      "maxExceededSimple": "價格不能超過99999"
+    },
+    "packageCredits": {
+      "min": "學分至少需要1個",
+      "maxExceeded": "學分不能超過99999"
+    },
+    "duration": {
+      "min": "期限至少需要1天",
+      "maxExceeded": "期限不能超過10年"
+    },
+    "classType": {
+      "required": "課程類型為必填項"
+    },
+    "location": {
+      "required": "地點為必填項"
+    },
+    "weeklyDays": {
+      "required": "至少需要選擇一天"
+    },
+    "startTime": {
+      "required": "開始時間為必填項",
+      "invalid": "請輸入有效的時間"
+    },
+    "endTime": {
+      "required": "結束時間為必填項",
+      "invalid": "請輸入有效的時間"
+    },
+    "startDate": {
+      "required": "開始日期為必填項"
+    },
+    "endDate": {
+      "afterStart": "結束日期必須在開始日期之後或相等"
+    },
+    "maxCapacity": {
+      "min": "最大容量至少需要1",
+      "maxExceeded": "最大容量不能超過1000"
+    },
+    "creditCost": {
+      "negative": "學分成本不能為負數",
+      "maxExceeded": "學分成本不能超過1000"
+    },
+    "className": {
+      "required": "課程名稱為必填項",
+      "minLength": "課程名稱至少需要2個字符",
+      "maxLength": "課程名稱不能超過100個字符"
+    },
+    "classTypeName": {
+      "required": "課程類型名稱為必填項",
+      "minLength": "課程類型名稱至少需要2個字符",
+      "maxLength": "課程類型名稱不能超過100個字符"
+    },
+    "durationMinutes": {
+      "min": "時長至少需要15分鐘",
+      "maxExceeded": "時長不能超過8小時"
+    },
+    "maxStudents": {
+      "min": "最大學生數至少需要1",
+      "maxExceeded": "最大學生數不能超過50"
+    },
+    "website": {
+      "invalid": "請輸入有效的網址"
+    },
+    "packageType": {
+      "required": "請選擇套票類型"
+    },
+    "package": {
+      "required": "請選擇套票"
+    },
+    "customPrice": {
+      "negative": "自定義價格不能為負數",
+      "maxExceeded": "自定義價格不能超過$99,999.99",
+      "required": "自定義套票需要價格"
+    },
+    "customCredits": {
+      "min": "學分至少需要1個",
+      "maxExceeded": "學分不能超過99999",
+      "required": "自定義套票需要學分"
+    },
+    "customDuration": {
+      "min": "期限至少需要1天",
+      "maxExceeded": "期限不能超過10年",
+      "required": "自定義套票需要期限"
+    },
+    "defaultCreditCost": {
+      "negative": "預設學分成本不能為負數",
+      "maxExceeded": "預設學分成本不能超過1000"
+    }
   },
   "common": {
     "save": "儲存",

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -97,7 +97,7 @@
 </template>
 
 <script setup lang="ts">
-import type { LoginForm } from '~/composables/useAuthValidation'
+import type { LoginForm } from '~/composables/useTranslatedValidation'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { clearAllData } from '~/utils/dbHelper'
 
@@ -107,7 +107,7 @@ definePageMeta({
 })
 
 const { auth, login, checkFirstTimeSetup } = useAuth()
-const { loginSchema } = useAuthValidation()
+const { loginSchema } = useTranslatedValidation()
 const { isDark, toggleDarkMode } = useDarkMode()
 
 // Check for first time setup

--- a/pages/packages.vue
+++ b/pages/packages.vue
@@ -93,7 +93,7 @@
 </template>
 
 <script setup lang="ts">
-import type { PackageForm } from '~/composables/usePackageValidation'
+import type { PackageForm } from '~/composables/useTranslatedValidation'
 
 definePageMeta({
   middleware: 'auth'

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -157,7 +157,7 @@
 </template>
 
 <script setup lang="ts">
-import type { RegisterForm } from '~/composables/useAuthValidation'
+import type { RegisterForm } from '~/composables/useTranslatedValidation'
 import type { FormSubmitEvent } from '@nuxt/ui'
 
 // Use blank layout for register page
@@ -167,7 +167,7 @@ definePageMeta({
 
 const { createUser } = useUsers()
 const { isDark, toggleDarkMode } = useDarkMode()
-const { registerSchema } = useAuthValidation()
+const { registerSchema } = useTranslatedValidation()
 
 const { t, locale, setLocale } = useI18n()
 const loading = ref(false)

--- a/pages/students/index.vue
+++ b/pages/students/index.vue
@@ -78,7 +78,7 @@
 </template>
 
 <script setup lang="ts">
-import type { StudentForm } from '~/composables/useStudentValidation'
+import type { StudentForm } from '~/composables/useTranslatedValidation'
 
 const { students, addStudent, updateStudent, deleteStudent, loadStudents } = useStudents()
 const { t } = useI18n()


### PR DESCRIPTION
Translate all form validation rules to improve the international user experience.

The existing form validation error messages were hardcoded in English. This PR introduces a new composable (`useTranslatedValidation`) that provides Zod schemas with dynamically translated error messages using `vue-i18n`, and updates all relevant forms to use these new schemas. It also adds the necessary translation keys to the English and Traditional Chinese locale files.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c3db520-4ed9-490e-9f91-d9ccfbdd7b75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c3db520-4ed9-490e-9f91-d9ccfbdd7b75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>