### PR TITLE
Auto select location for single option classes

### DIFF
--- a/components/ClassForm.vue
+++ b/components/ClassForm.vue
@@ -420,6 +420,14 @@ watch(() => modelValue.value, (newValue) => {
   }
 })
 
+// Auto-select location when there's only one option available
+watch(() => locations.value, (newLocations) => {
+  if (newLocations.length === 1 && !form.location_id && !props.class_) {
+    // Auto-select the only available location for new classes
+    form.location_id = newLocations[0].id
+  }
+}, { immediate: true })
+
 const resetForm = () => {
   const today = new Date()
   const tomorrow = new Date(today)


### PR DESCRIPTION
Auto-select location in ClassForm when only one option is available to improve user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-c878afa8-6783-482c-a37a-ea8a1083487f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c878afa8-6783-482c-a37a-ea8a1083487f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>