### PR TITLE
Add resend whatsapp message for transactions

### DIFF
--- a/app/pages/transactions.vue
+++ b/app/pages/transactions.vue
@@ -195,18 +195,6 @@
           :loading="loading"
           class="flex-1"
         >
-          <template #cell-actions="{ row }">
-            <div class="flex items-center gap-2">
-              <UButton
-                size="xs"
-                variant="soft"
-                color="success"
-                icon="i-simple-icons-whatsapp"
-                @click="openTransactionWhatsApp(row.original)"
-                :title="t('transaction.sendWhatsApp')"
-              />
-            </div>
-          </template>
         </UTable>
         </div>
         <!-- Empty State -->
@@ -225,6 +213,7 @@
 </template>
 
 <script setup lang="ts">
+import { UButton } from '#components'
 import { CalendarDate, DateFormatter, getLocalTimeZone } from '@internationalized/date'
 const { t, locale } = useI18n()
 const { getRecentTransactions, getTransactionStats, getTransactionsByStudent, getTransactionsByDateRange } = useTransactions()
@@ -322,14 +311,18 @@ const columns = [
   {
     accessorKey: 'actions',
     header: t('transactions.actions'),
-    sortable: false
-  }
-  // TODO : add action later
-  // {
-  //   accessorKey: 'actions',
-  //   header: t('transactions.actions'),
-  //   sortable: false
-  // }
+    sortable: false,
+    cell: ({row}:any) => {
+      return h(UButton, {
+        size: 'xs',
+        variant: 'soft',
+        color: 'success',
+        icon: 'i-simple-icons-whatsapp',
+        onClick: () =>openTransactionWhatsApp(row.original)
+      })
+    }
+  },
+
 ]
 
 // Methods


### PR DESCRIPTION
Add a 'Send WhatsApp' action to the transactions page to allow re-sending messages for any transaction.

This PR introduces an 'Actions' column with a WhatsApp button in the transactions table. Clicking the button fetches relevant transaction details (student, package, class, booking) and reuses the existing `showTransactionDetailsDialog` to compose and send the message.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8baecb4-8ec9-4be1-88bf-682889cc9356">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f8baecb4-8ec9-4be1-88bf-682889cc9356">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

